### PR TITLE
sepolicy: Introduce automated DC Dimming [3/3]

### DIFF
--- a/common/private/file.te
+++ b/common/private/file.te
@@ -1,2 +1,5 @@
 type sdcard_posix, sdcard_type, sdcard_posix_contextmount_type, fs_type, mlstrustedobject;
 type adbroot_data_file, file_type, data_file_type, core_data_file_type;
+
+# DC Dimming
+type vendor_sysfs_dc_dim, fs_type, sysfs_type;

--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -12,3 +12,6 @@ hal_client_domain(platform_app, hal_lineage_powershare)
 
 # MatLog calls dmesg
 allow platform_app kernel:system syslog_read;
+
+# DC Dimming
+allow platform_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -1,0 +1,2 @@
+# DC Dimming
+allow priv_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/service.te
+++ b/common/private/service.te
@@ -4,3 +4,5 @@ type lineage_livedisplay_service, system_api_service, system_server_service, ser
 type lineage_profile_service, system_api_service, system_server_service, service_manager_type;
 type lineage_trust_service, system_api_service, system_server_service, service_manager_type;
 type app_lock_service, system_api_service, system_server_service, service_manager_type;
+
+type dc_dimming_service, system_api_service, system_server_service, service_manager_type;

--- a/common/private/service_contexts
+++ b/common/private/service_contexts
@@ -6,3 +6,6 @@ profile                                   u:object_r:lineage_profile_service:s0
 adbroot_service                           u:object_r:adbroot_service:s0
 
 app_lock                                  u:object_r:app_lock_service:s0
+
+# DC Dimming
+dc_dim_service		                  u:object_r:dc_dimming_service:s0

--- a/common/private/system_server.te
+++ b/common/private/system_server.te
@@ -2,6 +2,10 @@ allow system_server storage_stub_file:dir getattr;
 
 allow system_server adbroot_service:service_manager find;
 
+# DC Dimming
+allow system_server vendor_sysfs_dc_dim:file rw_file_perms;
+add_service(system_server, dc_dimming_service);
+
 add_service(system_server, app_lock_service);
 
 # Use HALs


### PR DESCRIPTION
* Label sysfs node as sysfs_dc_dim in device tree

Change-Id: Ic50a616037dc744943ca1a7c04c506827ef50526