### PR TITLE
sepolicy: Introduce automated DC Dimming [3/3]

### DIFF
--- a/common/private/file.te
+++ b/common/private/file.te
@@ -2,7 +2,4 @@ type sdcard_posix, sdcard_type, sdcard_posix_contextmount_type, fs_type, mlstrus
 type adbroot_data_file, file_type, data_file_type, core_data_file_type;
 type sysfs_perdev_minors, fs_type, sysfs_type;
 
-# DC Dimming
-type vendor_sysfs_dc_dim, fs_type, sysfs_type;
-
 type pocket_judge_sysfs, fs_type, sysfs_type;

--- a/common/private/platform_app.te
+++ b/common/private/platform_app.te
@@ -12,6 +12,3 @@ hal_client_domain(platform_app, hal_lineage_powershare)
 
 # MatLog calls dmesg
 allow platform_app kernel:system syslog_read;
-
-# DC Dimming
-allow platform_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/priv_app.te
+++ b/common/private/priv_app.te
@@ -1,2 +1,0 @@
-# DC Dimming
-allow priv_app vendor_sysfs_dc_dim:file rw_file_perms;

--- a/common/private/service.te
+++ b/common/private/service.te
@@ -7,6 +7,7 @@ type lineage_profile_service, system_api_service, system_server_service, service
 type lineage_trust_service, system_api_service, system_server_service, service_manager_type;
 type app_lock_service, system_api_service, system_server_service, service_manager_type;
 
-type dc_dimming_service, system_api_service, system_server_service, service_manager_type;
-
 type pocket_service, system_api_service, system_server_service, service_manager_type;
+
+# DC Dimming
+type dc_dimming_service, system_api_service, system_server_service, service_manager_type;

--- a/common/private/service_contexts
+++ b/common/private/service_contexts
@@ -8,7 +8,7 @@ adbroot_service                           u:object_r:adbroot_service:s0
 
 app_lock                                  u:object_r:app_lock_service:s0
 
-# DC Dimming
-dc_dim_service		                  u:object_r:dc_dimming_service:s0
-
 pocket                                    u:object_r:pocket_service:s0
+
+# DC Dimming
+dc_dim_service                            u:object_r:dc_dimming_service:s0

--- a/common/private/system_app.te
+++ b/common/private/system_app.te
@@ -8,3 +8,7 @@ hal_client_domain(system_app, hal_lineage_touch)
 
 # Allow SetupWizard to set recovery update prop
 set_prop(system_app, recovery_update_prop)
+
+# DC Dimming
+allow system_server vendor_sysfs_dc_dim:file rw_file_perms;
+add_service(system_server, dc_dimming_service);

--- a/common/private/system_server.te
+++ b/common/private/system_server.te
@@ -2,10 +2,6 @@ allow system_server storage_stub_file:dir getattr;
 
 allow system_server adbroot_service:service_manager find;
 
-# DC Dimming
-allow system_server vendor_sysfs_dc_dim:file rw_file_perms;
-add_service(system_server, dc_dimming_service);
-
 add_service(system_server, app_lock_service);
 
 

--- a/common/public/file.te
+++ b/common/public/file.te
@@ -1,0 +1,2 @@
+# DC Dimming
+type vendor_sysfs_dc_dim, fs_type, sysfs_type;


### PR DESCRIPTION
* Label sysfs node as vendor_sysfs_dc_dim in device tree.

Change-Id: Ie370de435763e9eb4e10940bd9b2484650c3cdce