### PR TITLE
Update hal_lineage_health_default.te to fix the ERROR 'syntax error' …

### DIFF
--- a/qcom/vendor/hal_lineage_health_default.te
+++ b/qcom/vendor/hal_lineage_health_default.te
@@ -1,2 +1,7 @@
-rw_dir_file(hal_lineage_health_default, sysfs_battery_supply)
-rw_dir_file(hal_lineage_health_default, sysfs_usb_supply)
+# rw_dir_file(hal_lineage_health_default, sysfs_battery_supply)
+allow hal_lineage_health_default sysfs_battery_supply:dir rw_dir_perms;
+allow hal_lineage_health_default sysfs_battery_supply:file rw_file_perms;
+
+# rw_dir_file(hal_lineage_health_default, sysfs_usb_supply)
+allow hal_lineage_health_default sysfs_usb_supply:dir rw_dir_perms;
+allow hal_lineage_health_default sysfs_usb_supply:file rw_file_perms;


### PR DESCRIPTION
…at token 'rw_dir_file'  issue

Update hal_lineage_health_default.te to fix the ERROR 'syntax error' at token 'rw_dir_file'  [issue] (https://github.com/SuperiorOS/android_device_superior_sepolicy/issues/7)